### PR TITLE
Feature - getType function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,19 @@
 var colorObj = {
+  getType: function (colorStr) {
+    const hexRegex = /^#([A-F0-9]{3}|[A-F0-9]{6})$/i;
+
+    const rgbRegex = /^(([0-9]|([1-9][0-9])|(1[0-9][0-9])|2[0-4][0-9]|25[0-5]), ){2}([0-9]|([1-9][0-9])|(1[0-9][0-9])|2[0-4][0-9]|25[0-5])$/;
+
+    if (hexRegex.test(colorStr)) {
+      return 'hex';
+    }
+
+    if (rgbRegex.test(colorStr)) {
+      return 'rgb';
+    }
+
+    return undefined
+  },
   toHex: function (rgbStr) {
     // expect 1 parameters ;
     // break up into 3 parts;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var colorObj = {
       return 'rgb';
     }
 
-    return undefined
+    return undefined;
   },
   toHex: function (rgbStr) {
     // expect 1 parameters ;

--- a/test.js
+++ b/test.js
@@ -6,23 +6,23 @@ const assert = require('assert');
 assert.deepEqual(Color.toHex('100,200,255'), '#64C8FF');
 
 // getType
-assert.deepEqual(Color.getType('#000000'), 'hex')
-assert.deepEqual(Color.getType('#000'), 'hex')
-assert.deepEqual(Color.getType('#ABC'), 'hex')
-assert.deepEqual(Color.getType('#abc'), 'hex')
-assert.deepEqual(Color.getType('#aBc'), 'hex')
-assert.deepEqual(Color.getType('#A01'), 'hex')
-assert.deepEqual(Color.getType('0, 0, 0'), 'rgb')
-assert.deepEqual(Color.getType('255, 255, 255'), 'rgb')
-assert.deepEqual(Color.getType('123, 123, 123'), 'rgb')
-assert.deepEqual(Color.getType('000000'), undefined)
-assert.deepEqual(Color.getType('#1234'), undefined)
-assert.deepEqual(Color.getType('#12345'), undefined)
-assert.deepEqual(Color.getType('#12345X'), undefined)
-assert.deepEqual(Color.getType('0, 0, 256'), undefined)
-assert.deepEqual(Color.getType('0, 0, 01'), undefined)
-assert.deepEqual(Color.getType('255, 255, 0255'), undefined)
-assert.deepEqual(Color.getType('10, 10, 1000'), undefined)
-assert.deepEqual(Color.getType('1,1,1'), undefined)
-assert.deepEqual(Color.getType(' 1, 1, 1'), undefined)
-assert.deepEqual(Color.getType('1, 1, 1 '), undefined)
+assert.deepEqual(Color.getType('#000000'), 'hex');
+assert.deepEqual(Color.getType('#000'), 'hex');
+assert.deepEqual(Color.getType('#ABC'), 'hex');
+assert.deepEqual(Color.getType('#abc'), 'hex');
+assert.deepEqual(Color.getType('#aBc'), 'hex');
+assert.deepEqual(Color.getType('#A01'), 'hex');
+assert.deepEqual(Color.getType('0, 0, 0'), 'rgb');
+assert.deepEqual(Color.getType('255, 255, 255'), 'rgb');
+assert.deepEqual(Color.getType('123, 123, 123'), 'rgb');
+assert.deepEqual(Color.getType('000000'), undefined);
+assert.deepEqual(Color.getType('#1234'), undefined);
+assert.deepEqual(Color.getType('#12345'), undefined);
+assert.deepEqual(Color.getType('#12345X'), undefined);
+assert.deepEqual(Color.getType('0, 0, 256'), undefined);
+assert.deepEqual(Color.getType('0, 0, 01'), undefined);
+assert.deepEqual(Color.getType('255, 255, 0255'), undefined);
+assert.deepEqual(Color.getType('10, 10, 1000'), undefined);
+assert.deepEqual(Color.getType('1,1,1'), undefined);
+assert.deepEqual(Color.getType(' 1, 1, 1'), undefined);
+assert.deepEqual(Color.getType('1, 1, 1 '), undefined);

--- a/test.js
+++ b/test.js
@@ -4,3 +4,25 @@ const assert = require('assert');
 // assert.deepEqual(Color.toRGB('#F8E100'), '248, 225, 0');
 
 assert.deepEqual(Color.toHex('100,200,255'), '#64C8FF');
+
+// getType
+assert.deepEqual(Color.getType('#000000'), 'hex')
+assert.deepEqual(Color.getType('#000'), 'hex')
+assert.deepEqual(Color.getType('#ABC'), 'hex')
+assert.deepEqual(Color.getType('#abc'), 'hex')
+assert.deepEqual(Color.getType('#aBc'), 'hex')
+assert.deepEqual(Color.getType('#A01'), 'hex')
+assert.deepEqual(Color.getType('0, 0, 0'), 'rgb')
+assert.deepEqual(Color.getType('255, 255, 255'), 'rgb')
+assert.deepEqual(Color.getType('123, 123, 123'), 'rgb')
+assert.deepEqual(Color.getType('000000'), undefined)
+assert.deepEqual(Color.getType('#1234'), undefined)
+assert.deepEqual(Color.getType('#12345'), undefined)
+assert.deepEqual(Color.getType('#12345X'), undefined)
+assert.deepEqual(Color.getType('0, 0, 256'), undefined)
+assert.deepEqual(Color.getType('0, 0, 01'), undefined)
+assert.deepEqual(Color.getType('255, 255, 0255'), undefined)
+assert.deepEqual(Color.getType('10, 10, 1000'), undefined)
+assert.deepEqual(Color.getType('1,1,1'), undefined)
+assert.deepEqual(Color.getType(' 1, 1, 1'), undefined)
+assert.deepEqual(Color.getType('1, 1, 1 '), undefined)


### PR DESCRIPTION
### Changes
- Create `getType` function;
- Add tests for `getType`.

### Context
This PR addresses #7. Perhaps `rgbRegex` could be shortened a bit. :sweat_smile: